### PR TITLE
Update sbt and migrate publishing to GitLab

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target/
 .idea/
+.bsp/

--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ This is a Work In Progress...
 ## Installation
 
 ```
-resolvers += "Agilogy GitLab" at "https://gitlab.com/api/v4/groups/583742/packages/maven"
+resolvers += "Agilogy GitLab" at "https://gitlab.com/api/v4/groups/583742/-/packages/maven"
 
-libraryDependencies += "com.agilogy" %% "srdb-core" % "2.0"
+libraryDependencies += "com.agilogy" %% "srdb-core" % "2.2"
 ```
 
 ## Usage
@@ -113,7 +113,7 @@ import mySrdb._
 To publish this package to Agilogy's Package Registry, set the `GITLAB_DEPLOY_TOKEN` environment variable and then run the following command in sbt:
 
 ```
-sbt:simple-db> +publish
+sbt:srdb-core> +publish
 ```
 
 ## Copyright

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This is a Work In Progress...
 ## Installation
 
 ```
-resolvers += Resolver.url("Agilogy Scala",url("http://dl.bintray.com/agilogy/scala/"))(Resolver.ivyStylePatterns)
+resolvers += "Agilogy GitLab" at "https://gitlab.com/api/v4/groups/583742/packages/maven"
 
 libraryDependencies += "com.agilogy" %% "srdb-core" % "2.0"
 ```
@@ -106,6 +106,14 @@ To use your own exception translator, create an Srdb instance using `withExcepti
 ```
 val mySrdb:Srdb = com.agilogy.srdb.withExceptionTranslator((ctx,sql,exc) => exc)
 import mySrdb._
+```
+
+## Publishing
+
+To publish this package to Agilogy's Package Registry, set the `GITLAB_DEPLOY_TOKEN` environment variable and then run the following command in sbt:
+
+```
+sbt:simple-db> +publish
 ```
 
 ## Copyright

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-import bintray.Keys._
+import com.gilcloud.sbt.gitlab.{GitlabCredentials,GitlabPlugin}
 
 organization := "com.agilogy"
 
@@ -6,7 +6,7 @@ name := "srdb-core"
 
 scalaVersion := "2.12.6"
 
-crossScalaVersions := Seq("2.10.6","2.11.7","2.12.6")
+crossScalaVersions := Seq("2.11.7","2.12.6")
 
 libraryDependencies ++= Seq(
   "org.postgresql" % "postgresql" % "9.3-1102-jdbc41" % "test",
@@ -72,32 +72,27 @@ scalastyleFailOnError := true
 
 // Reformat at every compile.
 // See https://github.com/sbt/sbt-scalariform
-scalariformSettings
 
 coverageExcludedPackages := "<empty>"
 
-// --> bintray
+// --> gitlab
 
-seq(bintrayPublishSettings:_*)
+GitlabPlugin.autoImport.gitlabGroupId := None
+GitlabPlugin.autoImport.gitlabProjectId := Some(26236490)
+GitlabPlugin.autoImport.gitlabDomain := "gitlab.com"
 
-repository in bintray := "scala"
+GitlabPlugin.autoImport.gitlabCredentials := {
+    val token = sys.env.get("GITLAB_DEPLOY_TOKEN") match {
+        case Some(token) => token
+        case None =>
+            sLog.value.warn(s"Environment variable GITLAB_DEPLOY_TOKEN is undefined, 'publish' will fail.")
+            ""
+    }
+    Some(GitlabCredentials("Deploy-Token", token))
+}
 
-bintrayOrganization in bintray := Some("agilogy")
-
-packageLabels in bintray := Seq("scala")
-
-licenses += ("Apache-2.0", url("https://www.apache.org/licenses/LICENSE-2.0.html"))
-
-// <-- bintray
+// <-- gitlab
 
 enablePlugins(GitVersioning)
 
 git.useGitDescribe := true
-
-publishMavenStyle := isSnapshot.value
-
-publishTo := {
-  val nexus = "http://188.166.95.201:8081/content/repositories/snapshots"
-  if (isSnapshot.value) Some("snapshots"  at nexus)
-  else publishTo.value
-}

--- a/project/bintray.sbt
+++ b/project/bintray.sbt
@@ -1,6 +1,0 @@
-resolvers += Resolver.url(
-  "bintray-sbt-plugin-releases",
-  url("http://dl.bintray.com/content/sbt/sbt-plugin-releases"))(
-    Resolver.ivyStylePatterns)
-
-addSbtPlugin("me.lessis" % "bintray-sbt" % "0.2.1")

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.17
+sbt.version=1.4.9

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,8 +6,10 @@ addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.2.5")
 
 addSbtPlugin("org.wartremover" % "sbt-wartremover" % "2.2.1")
 
-addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.6.0")
+addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-scalariform" % "1.3.0")
+addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.3")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.8.5")
+addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "1.0.0")
+
+addSbtPlugin("com.gilcloud" % "sbt-gitlab" % "0.0.6")


### PR DESCRIPTION
Bintray is shutting down on May 1st, so we are moving to a different platform.
Packages for `srdb-core` are already published on [Agilogy's Package Registry](https://gitlab.com/groups/agilogy/-/packages) on GitLab.
Please also add the `v2.2` tag to the most recent commit of this PR.